### PR TITLE
Removed TODO, use hasMatches() instead of findAnyMatch().isPresent()

### DIFF
--- a/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_1.java
+++ b/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_1.java
@@ -1,5 +1,6 @@
 package de.upb.mbse.taxcalculationexample.businessrules.structuralsemantics;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -16,13 +17,13 @@ public class Chapter2StructuralSemantics_1 extends StructuralSemanticsTest {
 
 	@Test
 	public void patternMatching() {
-		assertTrue("There shoud be two matches", api.kundeMitMindestensZweiUmsaetzen().countMatches() == 2);
+		assertEquals("There shoud be two matches", 2, api.kundeMitMindestensZweiUmsaetzen().countMatches());
 	}
 
 	@Test
 	public void jedesModellMussEineBankHaben() {
-		assertTrue("There must be at least one bank", api.jedesModellMussEineBankHaben().findAnyMatch().isPresent());
+		assertTrue("There must be at least one bank", api.jedesModellMussEineBankHaben().hasMatches());
 		api.jedesModellMussEineBankHaben().findAnyMatch().ifPresent(m -> EcoreUtil.delete(m.getBank()));
-		assertFalse("There must be at least one bank", api.jedesModellMussEineBankHaben().findAnyMatch().isPresent());
+		assertFalse("There must be at least one bank", api.jedesModellMussEineBankHaben().hasMatches());
 	}
 }

--- a/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_2.java
+++ b/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_2.java
@@ -14,6 +14,6 @@ public class Chapter2StructuralSemantics_2 extends StructuralSemanticsTest {
 
 	@Test
 	public void keineZweiBankenMitKunden() {
-		assertTrue("The constraint should be violated", api.nichtMehrAlsEineBankMitKunden().findAnyMatch().isPresent());
+		assertTrue("The constraint should be violated", api.nichtMehrAlsEineBankMitKunden().hasMatches());
 	}
 }

--- a/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_3.java
+++ b/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_3.java
@@ -22,14 +22,12 @@ public class Chapter2StructuralSemantics_3 extends StructuralSemanticsTest {
 			System.out.println(m.getK2());
 		});
 
-		// FIXME[Patrick]: the match is non-injective as B2 and K2 are mapped to the
-		// same bank
-		assertFalse("The constraint is not violated", api.nichtMehrAlsEineBankMitKunden().findAnyMatch().isPresent());
+		assertFalse("The constraint is not violated", api.nichtMehrAlsEineBankMitKunden().hasMatches());
 	}
 
 	@Test
 	public void keineZweiBankenMitKundenComplete() {
-		assertTrue("The constraint is now violated", api.nichtMehrAlsEineBankMitKunden().findAnyMatch().isPresent()
-				|| api.nichtMehrAlsEineBankMitKundenEineBankIstKunde().findAnyMatch().isPresent());
+		assertTrue("The constraint is now violated", api.nichtMehrAlsEineBankMitKunden().hasMatches()
+				|| api.nichtMehrAlsEineBankMitKundenEineBankIstKunde().hasMatches());
 	}
 }

--- a/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_4.java
+++ b/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_4.java
@@ -15,7 +15,7 @@ public class Chapter2StructuralSemantics_4 extends Chapter2StructuralSemantics_3
 	@Test
 	@Override
 	public void keineZweiBankenMitKundenComplete() {
-		assertFalse("The constraint is not violated", api.nichtMehrAlsEineBankMitKunden().findAnyMatch().isPresent()
-				|| api.nichtMehrAlsEineBankMitKundenEineBankIstKunde().findAnyMatch().isPresent());
+		assertFalse("The constraint is not violated", api.nichtMehrAlsEineBankMitKunden().hasMatches()
+				|| api.nichtMehrAlsEineBankMitKundenEineBankIstKunde().hasMatches());
 	}
 }

--- a/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_5.java
+++ b/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_5.java
@@ -15,13 +15,13 @@ public class Chapter2StructuralSemantics_5 extends StructuralSemanticsTest {
 
 	@Test
 	public void ungueltigeDepotsUndUmsaetze() {
-		assertFalse("Constraint is violated", api.premise().findMatches().stream()
-				.allMatch(m_p -> api.conclusion().bind(m_p).findAnyMatch().isPresent()));
+		assertFalse("Constraint is violated",
+				api.premise().findMatches().stream().allMatch(m_p -> api.conclusion().bind(m_p).hasMatches()));
 	}
 
 	@Test
 	public void ungueltigeDepotsUndUmsaetzeNonCommutative() {
 		assertTrue("Constraint is (erroneously) not violated",
-				api.premise().findMatches().stream().allMatch(m_p -> api.conclusion().findAnyMatch().isPresent()));
+				api.premise().findMatches().stream().allMatch(m_p -> api.conclusion().hasMatches()));
 	}
 }

--- a/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_6.java
+++ b/de.upb.mbse.taxcalculationexample.businessrules/src/de/upb/mbse/taxcalculationexample/businessrules/structuralsemantics/Chapter2StructuralSemantics_6.java
@@ -20,7 +20,6 @@ public class Chapter2StructuralSemantics_6 extends StructuralSemanticsTest {
 						.stream()//
 						.allMatch(m_p -> api.conclusion()//
 								.bind(m_p)//
-								.findAnyMatch()//
-								.isPresent()));
+								.hasMatches()));
 	}
 }


### PR DESCRIPTION
Removed TODO fixed after https://github.com/eMoflon/emoflon-ibex-ui/pull/72.
