### PR TITLE
Remove warnings

### DIFF
--- a/de.upb.mbse.taxcalculationexample.businessrules/META-INF/MANIFEST.MF
+++ b/de.upb.mbse.taxcalculationexample.businessrules/META-INF/MANIFEST.MF
@@ -11,43 +11,12 @@ Bundle-Name: de.upb.mbse.taxcalculationexample.businessrules
 Bundle-Version: 0.0.1.qualifier
 Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.xmi,
+ org.emoflon.ibex.common,
  org.emoflon.ibex.gt,
- org.emoflon.ibex.common;bundle-version="1.0.0",
- org.emoflon.ibex.gt.democles;bundle-version="1.0.0",
- org.gervarro.democles.common;bundle-version="3.0.0",
- org.gervarro.democles.interpreter;bundle-version="1.0.0",
- org.gervarro.democles.emf;bundle-version="2.1.0",
- org.gervarro.democles.common.source;bundle-version="3.0.0",
- org.gervarro.democles.emf.source;bundle-version="2.1.0",
- org.gervarro.democles.interpreter.emf;bundle-version="1.0.0",
- org.gervarro.democles.interpreter.emf.source;bundle-version="1.0.0",
- org.gervarro.democles.interpreter.incremental;bundle-version="1.0.0",
- org.gervarro.democles.interpreter.incremental.emf;bundle-version="1.0
- .0",
- org.gervarro.democles.interpreter.incremental.emf.source;bundle-versi
- on="1.0.0",
- org.gervarro.democles.interpreter.incremental.source;bundle-version="
- 1.0.0",
- org.gervarro.democles.interpreter.lightning;bundle-version="1.0.0",
- org.gervarro.democles.interpreter.source;bundle-version="1.0.0",
- org.gervarro.democles.notification.emf;bundle-version="1.0.0",
- org.gervarro.democles.plan;bundle-version="3.0.0",
- org.gervarro.democles.plan.emf;bundle-version="1.0.0",
- org.gervarro.democles.plan.emf.source;bundle-version="1.0.0",
- org.gervarro.democles.plan.incremental.leaf;bundle-version="1.0.0",
- org.gervarro.democles.plan.source;bundle-version="3.0.0",
- org.gervarro.democles.specification.emf;bundle-version="3.0.0",
- org.gervarro.democles.specification.emf.source;bundle-version="3.0.0",
- org.gervarro.eclipse.task;bundle-version="1.0.1",
- org.gervarro.eclipse.workspace.autosetup;bundle-version="1.0.0",
- org.gervarro.eclipse.workspace.util;bundle-version="2.0.0",
- org.gervarro.notification;bundle-version="1.0.0",
- org.gervarro.notification.source;bundle-version="1.0.0",
- org.gervarro.plan.dynprog;bundle-version="1.0.1",
- org.gervarro.util;bundle-version="1.0.0",
- org.gervarro.util.source;bundle-version="1.0.0",
+ org.emoflon.ibex.gt.democles,
  org.junit
 Bundle-ManifestVersion: 2
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: 
+Automatic-Module-Name: de.upb.mbse.taxcalculationexample.businessrules


### PR DESCRIPTION
- Remove Democles dependency declarations (org.emoflon.ibex.gt.democles contains them already)
- The `.source` dependencies will cause errors if the plugins aren't installed separately (the setup as described in the install guide won't install them).
- Add a Automatic-Module-Name to avoid Java 9 compatibility warning in Eclipse Oxygen 3a